### PR TITLE
docs: fix missing {} on empty paths example

### DIFF
--- a/specification-structure.md
+++ b/specification-structure.md
@@ -97,7 +97,7 @@ openapi: 3.0.3
 info:
   title: A minimal OpenAPI document
   version: 0.0.1
-paths: # No endpoints defined
+paths: {} # No endpoints defined
 ```
 
 This API is not very useful because it **defines no operations** (it has no endpoints). [The next page](specification-paths.md) remedies that.


### PR DESCRIPTION
The minimal example was incorrect as it had an implicit `null` value for `paths` which is not allowed. In YAML the only way to spell the empty object is with JSON syntax: `{}`

Signed-off-by: Mike Ralphson <mike.ralphson@gmail.com>