### PR TITLE
Fix 404 links in figcaption

### DIFF
--- a/specification-components.md
+++ b/specification-components.md
@@ -16,7 +16,7 @@ accessible through the `components` field in the root [OpenAPI Object](https://s
 
 <figure style="text-align:center">
    <object type="image/svg+xml" data="img/components-object.svg"></object>
-  <figcaption>The OpenAPI Object is explained in the <a href="specification-structure.md">Structure of an OpenAPI Document</a> page.<br/>The Schema Object is explained in the <a href="specification-content.md">Content of Message Bodies</a> page.<br/>The Response Object is explained in the <a href="specification-paths.md">API Endpoints</a> page.<br/>The Parameter Object is explained in the <a href="specification-parameters.md">Parameters and Payload of an Operation</a> page.</figcaption>
+  <figcaption>The OpenAPI Object is explained in the <a href="specification-structure.html">Structure of an OpenAPI Document</a> page.<br/>The Schema Object is explained in the <a href="specification-content.html">Content of Message Bodies</a> page.<br/>The Response Object is explained in the <a href="specification-paths.html">API Endpoints</a> page.<br/>The Parameter Object is explained in the <a href="specification-parameters.html">Parameters and Payload of an Operation</a> page.</figcaption>
 </figure>
 
 Most objects in an OpenAPI document can be replaced by a **reference** to a **component**, drastically reducing the document's size and maintenance cost (just like methods do in programming languages).

--- a/specification-content.md
+++ b/specification-content.md
@@ -15,7 +15,7 @@ This field can be found both in [Response Objects](https://spec.openapis.org/oas
 
 <figure style="text-align:center">
   <object type="image/svg+xml" data="img/content-field.svg"></object>
-  <figcaption>The Response Object is explained in the <a href="specification-paths.md">API Endpoints</a> page.<br/>The Request Body Object is explained in the <a href="specification-parameters.md">Parameters and Payload of an Operation</a> page.</figcaption>
+  <figcaption>The Response Object is explained in the <a href="/Documentation/specification-paths.html">API Endpoints</a> page.<br/>The Request Body Object is explained in the <a href="/Documentation/specification-parameters.html">Parameters and Payload of an Operation</a> page.</figcaption>
 </figure>
 
 This allows returning content (or accepting content) in **different formats**, each one with a different structure described by the Media Type Object. **Wildcards** are accepted for the media types, with the more specific ones taking precedence over the generic ones.

--- a/specification-content.md
+++ b/specification-content.md
@@ -15,7 +15,7 @@ This field can be found both in [Response Objects](https://spec.openapis.org/oas
 
 <figure style="text-align:center">
   <object type="image/svg+xml" data="img/content-field.svg"></object>
-  <figcaption>The Response Object is explained in the <a href="/Documentation/specification-paths.html">API Endpoints</a> page.<br/>The Request Body Object is explained in the <a href="/Documentation/specification-parameters.html">Parameters and Payload of an Operation</a> page.</figcaption>
+  <figcaption>The Response Object is explained in the <a href="specification-paths.html">API Endpoints</a> page.<br/>The Request Body Object is explained in the <a href="specification-parameters.html">Parameters and Payload of an Operation</a> page.</figcaption>
 </figure>
 
 This allows returning content (or accepting content) in **different formats**, each one with a different structure described by the Media Type Object. **Wildcards** are accepted for the media types, with the more specific ones taking precedence over the generic ones.

--- a/specification-parameters.md
+++ b/specification-parameters.md
@@ -15,8 +15,8 @@ OpenAPI provides two mechanisms to specify input data, **parameters** and **requ
   <object type="image/svg+xml" data="img/parameter-object.svg"></object>
   <figcaption>
     The edges marked with an asterisk are arrays.<br/>
-    The Path Item and Operation Objects are explained in the <a href="specification-paths.md">API Endpoints</a> page.<br/>
-    The Media Type and Schema Objects are explained in the <a href="specification-content.md">Content of Message Bodies</a> page.
+    The Path Item and Operation Objects are explained in the <a href="specification-paths.html">API Endpoints</a> page.<br/>
+    The Media Type and Schema Objects are explained in the <a href="specification-content.html">Content of Message Bodies</a> page.
   </figcaption>
 </figure>
 
@@ -106,7 +106,7 @@ The tables given below exemplify the most common styles `simple`, `form`, `label
   |        | `1234`   | `id=1234` | `.1234` | `;id=1234` |
 
 - **Array types**: For example, an array named `ids` containing the integers 1, 2 and 3.
-  
+
   The `explode` field can be used to separate each element of the array into a separate parameter.
 
   | style:               | `simple` | `form`              | `label`  | `matrix`             |
@@ -115,7 +115,7 @@ The tables given below exemplify the most common styles `simple`, `form`, `label
   | with `explode=true`  | `1,2,3`  | `ids=1&ids=2&ids=3` | `.1.2.3` | `;ids=1;ids=2;ids=3` |
 
 - **Object types**: For example, an object named `color` containing integer fields R, G and B with values 1, 2 and 3.
-  
+
   Again, `explode` can be used to separate each field into a separate parameter.
 
   | style:               | `simple`      | `form`              | `label`        | `matrix`             |

--- a/specification-paths.md
+++ b/specification-paths.md
@@ -15,7 +15,7 @@ API Endpoints (also called Operations or Routes) are called **Paths** in the OAS
 
 <figure style="text-align:center">
   <object type="image/svg+xml" data="img/paths-object.svg"></object>
-  <figcaption>The OpenAPI Object is explained in the <a href="specification-structure.md">Structure of an OpenAPI Document</a> page.</figcaption>
+  <figcaption>The OpenAPI Object is explained in the <a href="specification-structure.html">Structure of an OpenAPI Document</a> page.</figcaption>
 </figure>
 
 Every field in the [Paths Object](https://spec.openapis.org/oas/v3.1.0#pathsObject) is a [Path Item Object](https://spec.openapis.org/oas/v3.1.0#pathItemObject) describing one API endpoint. Fields are used instead of an Array because they enforce endpoint name uniqueness at the syntax level (any JSON or YAML parser can detect mistakes without requiring an OpenAPI validator).

--- a/specification-servers.md
+++ b/specification-servers.md
@@ -15,7 +15,7 @@ The [Server Object](https://spec.openapis.org/oas/v3.1.0#serverObject) provides 
 
 <figure style="text-align:center">
   <object type="image/svg+xml" data="img/server-object.svg"></object>
-  <figcaption>The edges marked with an asterisk are arrays.<br/>The OpenAPI Object is explained in the <a href="specification-structure.md">Structure of an OpenAPI Document</a> page.<br/>The Paths, Path Item and Operation Objects are explained in the <a href="specification-paths.md">API Endpoints</a> page.</figcaption>
+  <figcaption>The edges marked with an asterisk are arrays.<br/>The OpenAPI Object is explained in the <a href="specification-structure.html">Structure of an OpenAPI Document</a> page.<br/>The Paths, Path Item and Operation Objects are explained in the <a href="specification-paths.html">API Endpoints</a> page.</figcaption>
 </figure>
 
 Each element in a `servers` array is a [Server Object](https://spec.openapis.org/oas/v3.1.0#serverObject) providing, at least, a `url` field with the base URL for that server. An optional `description` aids in keeping server lists organized:


### PR DESCRIPTION
On [https://oai.github.io/Documentation/specification-content.html](https://oai.github.io/Documentation/specification-content.html) (and others) two links in the `figcaption` are not being transformed, they still have their `.md` ending and lead the user to a 404 (compare to `previous page` link above it).

![screenshot_21-05-03_09:59:55](https://user-images.githubusercontent.com/25589715/116854019-4eaa7d80-abf7-11eb-9744-a83d267d254b.png)

The embedded html doesn't transform the `a`'s `href`.

**Proposed change**
As links are not getting dynamically transformed, transform them manually:
`xyz.md` -> `xyz.html`