### PR TITLE
Best practices: update a single source of truth

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -33,6 +33,8 @@ Otherwise, eventually one of the places will be updated while the other won't, l
 
 For instance, it is also commonplace to use code annotations to generate an OpenAPI description and then commit the latter to source control while the former still lingers in the code. As a result, newcomers to the project will not know which one is actually in use and mistakes will be made.
 
+Alternatively, you can use a Continuous Integration test to ensure that the two sources stay consistent.
+
 ## Add OpenAPI Documents to Source Control
 
 OpenAPI descriptions are **not** just a documentation artifact: they are **first-class source files** which can drive a great number of automated processes, including boilerplate generation, unit testing and documentation rendering.


### PR DESCRIPTION
offer another option to only keeping a single source of truth