### PR TITLE
Updating OAS links to properly link to sections

### DIFF
--- a/specification-paths.md
+++ b/specification-paths.md
@@ -11,14 +11,14 @@ nav_order: 2
 
 ## The Endpoints list
 
-API Endpoints (also called Operations or Routes) are called **Paths** in the OAS. The [Paths Object](https://spec.openapis.org/oas/v3.1.0#pathsObject), accessible through the `paths` field in the root [OpenAPI Object](https://spec.openapis.org/oas/v3.1.0#oasObject), is the container for all operations supported by the API:
+API Endpoints (also called Operations or Routes) are called **Paths** in the OAS. The [Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-object), accessible through the `paths` field in the root [OpenAPI Object](https://spec.openapis.org/oas/v3.1.0#openapi-object), is the container for all operations supported by the API:
 
 <figure style="text-align:center">
   <object type="image/svg+xml" data="img/paths-object.svg"></object>
   <figcaption>The OpenAPI Object is explained in the <a href="specification-structure.html">Structure of an OpenAPI Document</a> page.</figcaption>
 </figure>
 
-Every field in the [Paths Object](https://spec.openapis.org/oas/v3.1.0#pathsObject) is a [Path Item Object](https://spec.openapis.org/oas/v3.1.0#pathItemObject) describing one API endpoint. Fields are used instead of an Array because they enforce endpoint name uniqueness at the syntax level (any JSON or YAML parser can detect mistakes without requiring an OpenAPI validator).
+Every field in the [Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-object) is a [Path Item Object](https://spec.openapis.org/oas/v3.1.0#path-item-object) describing one API endpoint. Fields are used instead of an Array because they enforce endpoint name uniqueness at the syntax level (any JSON or YAML parser can detect mistakes without requiring an OpenAPI validator).
 
 Paths **must start with a forward slash** `/` since they are directly appended to the server URL (described in the [API Servers](specification-servers.md) page) to construct the full endpoint URL.
 
@@ -39,7 +39,7 @@ paths:
 
 ## The Path Item Object
 
-The [Path Item Object](https://spec.openapis.org/oas/v3.1.0#pathItemObject) describes the HTTP operations that can be performed on a path with a separate [Operation Object](https://spec.openapis.org/oas/v3.1.0#operationObject) for each one. Allowed operations match HTTP methods names like `get`, `put` or `delete`, to list the most common (find the complete list in the [Path Item Object](https://spec.openapis.org/oas/v3.1.0#pathItemObject) specification).
+The [Path Item Object](https://spec.openapis.org/oas/v3.1.0#path-item-object) describes the HTTP operations that can be performed on a path with a separate [Operation Object](https://spec.openapis.org/oas/v3.1.0#operation-object) for each one. Allowed operations match HTTP methods names like `get`, `put` or `delete`, to list the most common (find the complete list in the [Path Item Object](https://spec.openapis.org/oas/v3.1.0#path-item-object) specification).
 
 This object also accepts common properties for all operations on the path like `summary` or `description`. The details of each operation are given in each child Operation object.
 
@@ -54,7 +54,7 @@ paths:
 
 ## The Operation Object
 
-Besides giving the operation a `summary` and a `description`, the [Operation Object](https://spec.openapis.org/oas/v3.1.0#operationObject) basically describes the operation's parameters, payload and possible server responses. The rest of this page explains the `responses` field, whereas parameters and payload are dealt with in [another page](specification-parameters.md).
+Besides giving the operation a `summary` and a `description`, the [Operation Object](https://spec.openapis.org/oas/v3.1.0#operation-object) basically describes the operation's parameters, payload and possible server responses. The rest of this page explains the `responses` field, whereas parameters and payload are dealt with in [another page](specification-parameters.md).
 
 ```yaml
 paths:
@@ -70,7 +70,7 @@ paths:
 
 ## The Responses Object
 
-The [Responses Object](https://spec.openapis.org/oas/v3.1.0#responsesObject) is a container for  the expected answers the server can give to this request. Each field name is an HTTP response code **enclosed in quotation marks** and its value is a [Response Object](https://spec.openapis.org/oas/v3.1.0#responseObject) (note there is no 's' at the end) containing details about the response.
+The [Responses Object](https://spec.openapis.org/oas/v3.1.0#responses-object) is a container for  the expected answers the server can give to this request. Each field name is an HTTP response code **enclosed in quotation marks** and its value is a [Response Object](https://spec.openapis.org/oas/v3.1.0#response-object) (note there is no 's' at the end) containing details about the response.
 
 At least one response must be given and it is recommended that it corresponds to the success case (typically HTTP response code 200). 5 wildcards are allowed: `1XX`, `2XX`, `3XX`, `4XX` and `5XX` (explicit codes take preference over wildcards).
 
@@ -87,7 +87,7 @@ paths:
 
 ## The Response Object
 
-The [Response Object](https://spec.openapis.org/oas/v3.1.0#responseObject) contains a **mandatory** `description` of the meaning of the response in the context of this operation, complementing the sense of the HTTP response codes (which are generic in nature). This helps developers understand better how to react to this particular code.
+The [Response Object](https://spec.openapis.org/oas/v3.1.0#response-object) contains a **mandatory** `description` of the meaning of the response in the context of this operation, complementing the sense of the HTTP response codes (which are generic in nature). This helps developers understand better how to react to this particular code.
 
 The most important field, though, is `content` because it describes the possible payloads of the response. Due to its complexity, this field's format is detailed next, in [its own page](specification-content.md).
 


### PR DESCRIPTION
## Issue
Link to the OAS in this document follow the camelCase format (ex. https://spec.openapis.org/oas/v3.1.0#pathItemObject). Unfortunately, this link will only have the sidebar direct you to the content, while the docs themselves (right-content) will take you to your most recently navigated to spot on the page ([example](https://i.imgur.com/LsKNTvJ.png))
![image](https://i.imgur.com/LsKNTvJ.png)

## Suggested fix
I suggest moving to kebab-case link which will actually take you to the content in the docs, rather than requiring a second click on the sidebar.
Ex. Try opening this in a new tab: [https://spec.openapis.org/oas/v3.1.0#path-item-object](https://spec.openapis.org/oas/v3.1.0#path-item-object). The sidebar won't point to the page unfortunately, but it isn't that hard to navigate and find your place



## Repro
Macbook Pro, Google Chrome (latest). Command click to open doc link in new tab (as I would expect most readers to do). Once you are in the doc, click on any link to another object.

https://user-images.githubusercontent.com/11202679/160473350-7255c9d6-8964-41cb-9ab9-49df51cb29da.mov


