### PR TITLE
fix: try to get remote theme working locally as well as deployed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.2"
 gem "just-the-docs", "~> 0.3.3"
 gem "webrick", "~> 1.7"
+gem "jekyll-remote-theme"
 
 group :jekyll_plugins do
   gem "jekyll-sitemap", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,11 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
@@ -59,6 +64,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (3.28.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -69,9 +75,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2)
+  jekyll-remote-theme
   jekyll-sitemap (~> 1.4)
   just-the-docs (~> 0.3.3)
   webrick (~> 1.7)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 #theme: just-the-docs
-remote_theme: pmarsceill/just-the-docs
+remote_theme: just-the-docs/just-the-docs
 title: OpenAPI Documentation
 description: For API designers and writers wishing formalize their API in an OpenAPI Description document.
 baseurl: /Documentation
@@ -13,6 +13,7 @@ color_scheme: oai
 highlighter: rouge
 plugins:
   - jekyll-sitemap
+  - jekyll-remote-theme
 exclude:
   - README.md
   - CONTRIBUTING.md


### PR DESCRIPTION
Deploys to Github pages were failing with "Warning: github-pages can't satisfy your Gemfile's dependencies" / "just-the-docs theme could not be found" with `theme` set in `_config.yml` so I had to set it back to `remote_theme`.

This change adds the `jekyll-remote-theme` gem to the local `Gemfile` so both local and deployed builds work the same.

The repo org for the `just-the-docs` theme has also changed, so this is updated too so we don't depend on a Github redirect.