### PR TITLE
docs: add a fork me on Github banner, closes #41

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,1 +1,4 @@
 <base target="_top">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
+<style>.github-fork-ribbon:before { background-color: #1d781d; }</style>
+<a class="github-fork-ribbon" href="https://github.com/OAI/Documentation" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>


### PR DESCRIPTION
Closes #41

This PR adds an OAI coloured 'Fork me on Github` banner top right using CSS from https://github.com/simonwhitaker/github-fork-ribbon-css - the aim is to prominently link to the documentation source and encourage contributions.

Tested locally and does not obscure the right hand hamburger menu when screen width is mobile-sized.