### PR TITLE
Fix broken inline links 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,5 +29,5 @@ Configuration file: /Users/phil/src/OAI/Documentation/_config.yml
 Alternatively, you can use the following Docker command to build and serve the documentation:
 
 ```shell
-docker run -v $(pwd):/site bretfisher/jekyll-serve
+docker run -v $(pwd):/site -p 4000:4000 bretfisher/jekyll-serve
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.2"
 gem "just-the-docs", "~> 0.3.3"
 gem "webrick", "~> 1.7"
+gem "jekyll-remote-theme"
 
 group :jekyll_plugins do
   gem "jekyll-sitemap", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,11 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
@@ -59,6 +64,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (3.28.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -69,9 +75,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2)
+  jekyll-remote-theme
   jekyll-sitemap (~> 1.4)
   just-the-docs (~> 0.3.3)
   webrick (~> 1.7)

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 #theme: just-the-docs
-remote_theme: pmarsceill/just-the-docs
+remote_theme: just-the-docs/just-the-docs
 title: OpenAPI Documentation
 description: For API designers and writers wishing formalize their API in an OpenAPI Description document.
 baseurl: /Documentation
@@ -13,6 +13,7 @@ color_scheme: oai
 highlighter: rouge
 plugins:
   - jekyll-sitemap
+  - jekyll-remote-theme
 exclude:
   - README.md
   - CONTRIBUTING.md

--- a/best-practices.md
+++ b/best-practices.md
@@ -6,7 +6,7 @@ nav_order: 4
 
 # Best Practices
 
-This page contains general pieces of advice which do not strictly belong to the [Specification Explained](specification.md) chapter because they are not directly tied to the OpenAPI Specification.
+This page contains general pieces of advice which do not strictly belong to the [Specification Explained](specification) chapter because they are not directly tied to the OpenAPI Specification.
 
 However, they greatly simplify creating and maintaining OpenAPI documents, so they are worth keeping in mind.
 
@@ -73,7 +73,7 @@ Instead, you should try the other existing creation methods and choose the one t
 
 This is a collection of small hints related to working with large API description documents.
 
-- **Do not repeat yourself** (The DRY principle). If the same piece of YAML or JSON appears more than once in the document, it's time to move it to the `components` section and reference it from other places using `$ref` (See [Reusing Descriptions](specification/components.md). Not only will the resulting document be smaller but it will also be much easier to maintain).
+- **Do not repeat yourself** (The DRY principle). If the same piece of YAML or JSON appears more than once in the document, it's time to move it to the `components` section and reference it from other places using `$ref` (See [Reusing Descriptions](specification/components). Not only will the resulting document be smaller but it will also be much easier to maintain).
 
   Components can be referenced from other files, so you can even reuse them across different API documents!
 
@@ -83,7 +83,7 @@ This is a collection of small hints related to working with large API descriptio
 
   Bear in mind that some tools might have issues with large files, whereas some other tools might not handle too many files gracefully. The solution will have to take your toolkit into account.
 
-- **Use tags to keep things organized**: [Tags](https://spec.openapis.org/oas/v3.1.0#oasTags) have not been described in the Specification chapter, but they can help you arrange your operations and find them faster. A tag is simply a piece of metadata (a unique name and an optional description) that you can attach to [operations](specification/paths.md). Tools, specially [GUI editors](https://openapi.tools/#gui-editors), can then sort all your API's operation by their tags to help you keep them organized.
+- **Use tags to keep things organized**: [Tags](https://spec.openapis.org/oas/v3.1.0#oasTags) have not been described in the Specification chapter, but they can help you arrange your operations and find them faster. A tag is simply a piece of metadata (a unique name and an optional description) that you can attach to [operations](specification/paths). Tools, specially [GUI editors](https://openapi.tools/#gui-editors), can then sort all your API's operation by their tags to help you keep them organized.
 
 ## Links to External Best Practices
 

--- a/index.md
+++ b/index.md
@@ -14,10 +14,10 @@ Machine-readable API descriptions are ubiquitous nowadays and **OpenAPI** is **t
 These pages are a companion to the [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0), helping the reader learn it and answering questions like "What is the best way to accomplish... ?" or "What is the purpose of... ?" that are naturally out of the scope of the specification.
 
 - If you are unsure if this guide is for you, read the next section below.
-- If you do not know what "API", "machine-readable description" or "OpenAPI" mean start by reading the [Introduction](introduction.md) chapter.
-- If this is your first time writing an **OpenAPI Description document** read [The OpenAPI Specification explained](specification.md) chapter for step-by-step tutorials.
-- If you already have **OpenAPI** experience but need help with a specific topic, take a look at the index of [The OpenAPI Specification explained](specification.md) chapter; it also includes advanced topics.
-- Finally, make sure you are aware of the recommended [Best Practices](best-practices.md) to take full advantage of **OpenAPI**!
+- If you do not know what "API", "machine-readable description" or "OpenAPI" mean start by reading the [Introduction](introduction) chapter.
+- If this is your first time writing an **OpenAPI Description document** read [The OpenAPI Specification explained](specification) chapter for step-by-step tutorials.
+- If you already have **OpenAPI** experience but need help with a specific topic, take a look at the index of [The OpenAPI Specification explained](specification) chapter; it also includes advanced topics.
+- Finally, make sure you are aware of the recommended [Best Practices](best-practices) to take full advantage of **OpenAPI**!
 - And of course, you can always refer to the actual [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0) for reference.
 
 ## Advantages of Using OpenAPI
@@ -36,6 +36,6 @@ On top of this, the **OpenAPI Specification** also provides you with:
 
 - **A non-proprietary format**: You have a say in the future direction of the Specification!
 - **The most developed tooling ecosystem**: As a direct result of the previous statement, OpenAPI offers a vast number of tools to work with it. Just take a quick look at [OpenAPI Tooling](https://tools.openapis.org).
-- **A format readable by both machines and humans**: Even though writing **OpenAPI** documents by hand is not the most convenient way of doing it (See [Best Practices](best-practices.md)), they are plain text files which can be easily browsed in case something needs to be debugged.
+- **A format readable by both machines and humans**: Even though writing **OpenAPI** documents by hand is not the most convenient way of doing it (See [Best Practices](best-practices)), they are plain text files which can be easily browsed in case something needs to be debugged.
 
 So, choose your desired entry point from the list at the top of this page and start your journey!

--- a/introduction.md
+++ b/introduction.md
@@ -11,7 +11,7 @@ The **OpenAPI Specification** allows the description of a remote API accessible 
 
 The concept of an "API" is described first and the advantages of describing APIs using a machine-readable format are introduced, followed by the benefits of using the OpenAPI format. In the last section, the evolution of API descriptions is put into perspective with a brief historical summary.
 
-If you are already familiar with the benefits of machine-readable API descriptions and the OpenAPI in particular you may skip ahead to the next chapter, [The OpenAPI Specification explained](specification.md).
+If you are already familiar with the benefits of machine-readable API descriptions and the OpenAPI in particular you may skip ahead to the next chapter, [The OpenAPI Specification explained](specification).
 
 ## What Is an API?
 
@@ -54,7 +54,7 @@ The next section shows how some of these problems can be alleviated by specifyin
 
 An **API description file** (sometimes called Contract) is a **machine-readable** specification of an API. It should strive to be as **complete**, and **fully-detailed** as possible, although absolute completeness is not usually a requirement. Also, just like legal contracts, the more **unambiguous** it is, the more useful it becomes.
 
-Its main advantage over documentation which only humans can read is that it enables **automated processing**, opening the door to the benefits listed at [the beginning of this guide](start-here.md).
+Its main advantage over documentation which only humans can read is that it enables **automated processing**, opening the door to the benefits listed at [the beginning of this guide](start-here).
 
 To begin with, documentation for humans including the list of available methods and their details can be easily generated from the API description file. Done as a step in the build process, this easily prevents out-of-sync docs.
 
@@ -83,7 +83,7 @@ If parts of your API cannot be described using the OAS, and they cannot be redes
 
 Finally, OpenAPI can describe APIs based on the HTTP protocol (like RESTful ones) but also APIs based on **HTTP-like protocols** like CoAP (Constrained Application Protocol) or WebSockets. This allows OpenAPI to be used in resource-restricted scenarios like IoT (Internet of Things), for example.
 
-Feel free to jump now to the next chapter, [The OpenAPI Specification explained](specification.md), to start learning how to use the OAS. Or stay a bit longer to gain historical perspective with a comparison of the evolution of local and remote API descriptions.
+Feel free to jump now to the next chapter, [The OpenAPI Specification explained](specification), to start learning how to use the OAS. Or stay a bit longer to gain historical perspective with a comparison of the evolution of local and remote API descriptions.
 
 ## A Brief Historical Comparison
 
@@ -101,4 +101,4 @@ Machine-readable API descriptions (including **OpenAPI**) were then invented to 
 
 The benefits delivered by machine-readable descriptions of remote APIs, though, have far surpassed those of method signatures. For instance, OpenAPI can attach examples and notes to most API sections, to complement the automatically-generated documents, or reuse parts of the description to make the whole file leaner.
 
-Learn about all these capabilities and more in the next chapter, [The OpenAPI Specification explained](specification.md).
+Learn about all these capabilities and more in the next chapter, [The OpenAPI Specification explained](specification).

--- a/specification/components.md
+++ b/specification/components.md
@@ -111,4 +111,4 @@ This page has shown that:
 - Components can be referenced from any place where an object of the same type is expected using `$ref`.
 - References are actually URIs so they are very flexible.
 
-[The next page](docs.md) explains how to include documentation and examples in an OpenAPI document.
+[The next page](docs) explains how to include documentation and examples in an OpenAPI document.

--- a/specification/content.md
+++ b/specification/content.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Content of Message Bodies
 
-[The previous page](paths.md) showed how to define API endpoints but it didn't explain how to describe the content of the responses through the `content` field. This page clarifies this important field, which can also be used to describe queries, as shown in the [Parameters page](parameters.md).
+[The previous page](paths) showed how to define API endpoints but it didn't explain how to describe the content of the responses through the `content` field. This page clarifies this important field, which can also be used to describe queries, as shown in the [Parameters page](parameters).
 
 ## The `content` Field
 
@@ -32,7 +32,7 @@ content:
 
 ## The Media Type Object
 
-The [Media Type Object](https://spec.openapis.org/oas/v3.1.0#media-type-object) describes the structure of the content and provides examples for documentation and mocking purposes (examples are dealt with in the [Documentation page](docs.md)).
+The [Media Type Object](https://spec.openapis.org/oas/v3.1.0#media-type-object) describes the structure of the content and provides examples for documentation and mocking purposes (examples are dealt with in the [Documentation page](docs)).
 
 The structure is described in the `schema` field explained next.
 
@@ -158,7 +158,7 @@ The response contains an object is JSON format with two fields:
 - `winner` is a string with only three possible values: `.`, `X` and `O`.
 - `board` is a 3-element array where each item is another 3-element array, effectively building a 3x3 square matrix. Each element in the matrix is a string with only three possible values: `.`, `X` and `O`.
 
-This document is starting to grow too big and complex. The [Reusing Descriptions](components.md) page explains how to name sections of an OpenAPI document in order to reuse them (like the strings with three options above, which appear twice).
+This document is starting to grow too big and complex. The [Reusing Descriptions](components) page explains how to name sections of an OpenAPI document in order to reuse them (like the strings with three options above, which appear twice).
 
 ## Summary
 
@@ -168,4 +168,4 @@ This page has shown how to describe the content of the body of a response or que
 - Each [Media Type Object](https://spec.openapis.org/oas/v3.1.0#media-type-object) has a `schema` field describing a [Schema Object](https://spec.openapis.org/oas/v3.1.0#schema-object).
 - [Schema Objects](https://spec.openapis.org/oas/v3.1.0#schema-object) define a data `type` which can be customized through multiple properties like `minimum`, `maximum`, `items`, `properties` and many more.
 
-[The next page](parameters.md) explains how to define the parameters that an endpoint accepts.
+[The next page](parameters) explains how to define the parameters that an endpoint accepts.

--- a/specification/docs.md
+++ b/specification/docs.md
@@ -195,4 +195,4 @@ This page has shown the features provided by OpenAPI to aid in the documentation
 - Text can use rich formatting using **CommonMark** syntax, quickly summarized in this page.
 - Documentation can be extended with sample code using the `example` or `examples` fields.
 
-[The next page](servers.md) shows how to specify the server where the API can be accessed.
+[The next page](servers) shows how to specify the server where the API can be accessed.

--- a/specification/index.md
+++ b/specification/index.md
@@ -11,10 +11,10 @@ The [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0) is the ultimat
 
 The following pages introduce the syntax and structure of an OpenAPI document, its main building blocks and a minimal API document. Afterwards, the different blocks are detailed, starting from the most common and progressing towards advanced ones.
 
-- [Structure of an OpenAPI Document](./specification/structure.md): JSON, YAML, `openapi` and `info`
-- [API Endpoints](specification/paths.md): `paths` and `responses`.
-- [Content of Message Bodies](specification/content.md): `content` and `schema`.
-- [Parameters and Payload of an Operation](specification/parameters.md): `parameters` and `requestBody`.
-- [Reusing Descriptions](specification/components.md): `components` and `$ref`.
-- [Providing Documentation and Examples](specification/docs.md): `example` and `examples`.
-- [API Servers](specification/servers.md): `servers`.
+- [Structure of an OpenAPI Document](./specification/structure): JSON, YAML, `openapi` and `info`
+- [API Endpoints](specification/paths): `paths` and `responses`.
+- [Content of Message Bodies](specification/content): `content` and `schema`.
+- [Parameters and Payload of an Operation](specification/parameters): `parameters` and `requestBody`.
+- [Reusing Descriptions](specification/components): `components` and `$ref`.
+- [Providing Documentation and Examples](specification/docs): `example` and `examples`.
+- [API Servers](specification/servers): `servers`.

--- a/specification/parameters.md
+++ b/specification/parameters.md
@@ -7,7 +7,7 @@ nav_order: 4
 
 # Parameters and Payload of an Operation
 
-[The previous page](content.md) has shown how to describe an operation's response format, this is, the **output data** of an operation. On the other hand, this page shows how to specify the **input data**, this is, the additional information that complements the endpoint and the operation to fully detail a request.
+[The previous page](content) has shown how to describe an operation's response format, this is, the **output data** of an operation. On the other hand, this page shows how to specify the **input data**, this is, the additional information that complements the endpoint and the operation to fully detail a request.
 
 OpenAPI provides two mechanisms to specify input data, **parameters** and **request body** (message payload). Parameters are typically used to identify a resource, whereas the message payload provides content for that resource.
 
@@ -86,9 +86,9 @@ parameters:
     maximum: 100
 ```
 
-The [Content of Message Bodies](content.md) page describes Schema objects in greater detail.
+The [Content of Message Bodies](content) page describes Schema objects in greater detail.
 
-In more advanced scenarios the `content` field can be used instead. It provides a **single-entry map** of Media Types to [Media Type Objects](https://spec.openapis.org/oas/v3.1.0#media-type-object) (More details can be found in the [Content of Message Bodies](content.md) page).
+In more advanced scenarios the `content` field can be used instead. It provides a **single-entry map** of Media Types to [Media Type Objects](https://spec.openapis.org/oas/v3.1.0#media-type-object) (More details can be found in the [Content of Message Bodies](content) page).
 
 > **NOTE**:
 > Exactly one of `schema` or `content` **must** be present. They cannot appear at the same time.
@@ -139,7 +139,7 @@ paths:
         ...
 ```
 
-The only mandatory field in the [Request Body Object](https://spec.openapis.org/oas/v3.1.0#request-body-object) is `content` which is described in detail in the [Content of Message Bodies](content.md) page.
+The only mandatory field in the [Request Body Object](https://spec.openapis.org/oas/v3.1.0#request-body-object) is `content` which is described in detail in the [Content of Message Bodies](content) page.
 
 As a reminder, the snippet below describes an operation with a JSON request body containing a single integer with values between 1 and 100.
 
@@ -199,7 +199,7 @@ paths:
 - The parameters are two integers, named `row` and `column` which are located in the path of the operation. This matches the path name which contains `{row}` and `{column}`.
 - The `put` operation, additionally, must provide a request body which must be one of the three provided strings: `.`, `X` and `O`.
 
-The complete [Tic Tac Toe sample API](examples/tictactoe.yaml) does not look exactly like the above snippet because it reuses portions of the document to remove redundancy. This technique is explained in the [Reusing Descriptions](components.md) page.
+The complete [Tic Tac Toe sample API](examples/tictactoe.yaml) does not look exactly like the above snippet because it reuses portions of the document to remove redundancy. This technique is explained in the [Reusing Descriptions](components) page.
 
 ## Summary
 
@@ -209,4 +209,4 @@ This page has shown:
 - Parameters can be located in different places (`path`, `query`, `headers`) and their content (`schema`) and serialization (`style`) is highly customizable.
 - The request body is specified, much like responses are, using the `content` field.
 
-[The next page](components.md) explains how to reuse portions of an OpenAPI document to remove redundancy, reducing file size and maintenance cost.
+[The next page](components) explains how to reuse portions of an OpenAPI document to remove redundancy, reducing file size and maintenance cost.

--- a/specification/paths.md
+++ b/specification/paths.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # API Endpoints
 
-[The previous page](structure.md) showed the minimal structure of an OpenAPI document but did not add any operation to the API. This page explains how to do it.
+[The previous page](structure) showed the minimal structure of an OpenAPI document but did not add any operation to the API. This page explains how to do it.
 
 ## The Endpoints list
 
@@ -20,7 +20,7 @@ API Endpoints (also called Operations or Routes) are called **Paths** in the OAS
 
 Every field in the [Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-object) is a [Path Item Object](https://spec.openapis.org/oas/v3.1.0#path-item-object) describing one API endpoint. Fields are used instead of an Array because they enforce endpoint name uniqueness at the syntax level (any JSON or YAML parser can detect mistakes without requiring an OpenAPI validator).
 
-Paths **must start with a forward slash** `/` since they are directly appended to the server URL (described in the [API Servers](servers.md) page) to construct the full endpoint URL.
+Paths **must start with a forward slash** `/` since they are directly appended to the server URL (described in the [API Servers](servers) page) to construct the full endpoint URL.
 
 The [Tic Tac Toe sample API](examples/tictactoe.yaml) is used in this guide to exemplify each concept and it is built piece by piece as the guide progresses. Here's the first snippet already containing a single endpoint:
 
@@ -54,7 +54,7 @@ paths:
 
 ## The Operation Object
 
-Besides giving the operation a `summary` and a `description`, the [Operation Object](https://spec.openapis.org/oas/v3.1.0#operation-object) basically describes the operation's parameters, payload and possible server responses. The rest of this page explains the `responses` field, whereas parameters and payload are dealt with in [another page](parameters.md).
+Besides giving the operation a `summary` and a `description`, the [Operation Object](https://spec.openapis.org/oas/v3.1.0#operation-object) basically describes the operation's parameters, payload and possible server responses. The rest of this page explains the `responses` field, whereas parameters and payload are dealt with in [another page](parameters).
 
 ```yaml
 paths:
@@ -89,7 +89,7 @@ paths:
 
 The [Response Object](https://spec.openapis.org/oas/v3.1.0#response-object) contains a **mandatory** `description` of the meaning of the response in the context of this operation, complementing the sense of the HTTP response codes (which are generic in nature). This helps developers understand better how to react to this particular code.
 
-The most important field, though, is `content` because it describes the possible payloads of the response. Due to its complexity, this field's format is detailed next, in [its own page](content.md).
+The most important field, though, is `content` because it describes the possible payloads of the response. Due to its complexity, this field's format is detailed next, in [its own page](content).
 
 ```yaml
 paths:
@@ -133,4 +133,4 @@ The complete document can be found in the [Tic Tac Toe sample API](examples/tict
 
 This page has shown how to specify endpoints (`paths`), their available operations (`get`, `put`, ...) and their possible outcomes (`responses`).
 
-The [next page](content.md) shows how to specify the `content` of the responses.
+The [next page](content) shows how to specify the `content` of the responses.

--- a/specification/servers.md
+++ b/specification/servers.md
@@ -61,7 +61,7 @@ GET requests to the `/users` endpoint are served from `https://server2.com` and 
 >
 > If the servers are used for different environments (for example Testing and Production), chances are that their APIs will be different and describing them in a single document will be complicated.
 >
-> In these cases it is probably better to use different documents, and even different API versions. Read the [Reusing Descriptions](components.md) page to learn how to avoid code duplication and maintenance costs in these scenarios.
+> In these cases it is probably better to use different documents, and even different API versions. Read the [Reusing Descriptions](components) page to learn how to avoid code duplication and maintenance costs in these scenarios.
 
 Conversely, if no servers are provided, it is assumed that all API endpoints are relative to the location where the OpenAPI document is being served.
 

--- a/specification/structure.md
+++ b/specification/structure.md
@@ -100,7 +100,7 @@ info:
 paths: {} # No endpoints defined
 ```
 
-This API is not very useful because it **defines no operations** (it has no endpoints). [The next page](paths.md) remedies that.
+This API is not very useful because it **defines no operations** (it has no endpoints). [The next page](paths) remedies that.
 
 ## Summary
 
@@ -110,4 +110,4 @@ This page has shown that:
 * An OpenAPI document is a JSON object including the fields described in the [OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0).
 * Every OpenAPI document must contain a root object with at least the fields `openapi`, and `info`,  and either `paths`, `components` or `webhooks`.
 
-[The following page](paths.md) describes the contents of the `paths` field so endpoints can be added to the above minimal snippet.
+[The following page](paths) describes the contents of the `paths` field so endpoints can be added to the above minimal snippet.


### PR DESCRIPTION
Closes #46 

The latest version of `just-the-docs` no longer seems to rewrite internal links from `.md` to `.html`.