### PR TITLE
Fixed wrong path for the Tic Tac Toe sample API

### DIFF
--- a/specification/content.md
+++ b/specification/content.md
@@ -107,7 +107,7 @@ content:
 
 ## Tic Tac Toe Example
 
-The [Tic Tac Toe sample API](examples/tictactoe.yaml) given so far has one endpoint with one unspecified response. The snippet below adds the description of this content:
+The [Tic Tac Toe sample API](/examples/tictactoe.yaml) given so far has one endpoint with one unspecified response. The snippet below adds the description of this content:
 
 ```yaml
 openapi: 3.1.0

--- a/specification/parameters.md
+++ b/specification/parameters.md
@@ -157,7 +157,7 @@ The Request Body Object also has a `description` string and a `required` boolean
 
 ## Tic Tac Toe Example
 
-The [Tic Tac Toe sample API](examples/tictactoe.yaml) contains two endpoints, one without parameters or request body (`/board`) and another one with both (`/board/{row}/{column}`). The relevant code snippet for the second endpoint is shown below and it should be easy to understand after reading this page.
+The [Tic Tac Toe sample API](/examples/tictactoe.yaml) contains two endpoints, one without parameters or request body (`/board`) and another one with both (`/board/{row}/{column}`). The relevant code snippet for the second endpoint is shown below and it should be easy to understand after reading this page.
 
 ```yaml
 paths:

--- a/specification/paths.md
+++ b/specification/paths.md
@@ -22,7 +22,7 @@ Every field in the [Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-obj
 
 Paths **must start with a forward slash** `/` since they are directly appended to the server URL (described in the [API Servers](servers) page) to construct the full endpoint URL.
 
-The [Tic Tac Toe sample API](examples/tictactoe.yaml) is used in this guide to exemplify each concept and it is built piece by piece as the guide progresses. Here's the first snippet already containing a single endpoint:
+The [Tic Tac Toe sample API](/examples/tictactoe.yaml) is used in this guide to exemplify each concept and it is built piece by piece as the guide progresses. Here's the first snippet already containing a single endpoint:
 
 ```yaml
 openapi: 3.1.0
@@ -127,7 +127,7 @@ paths:
             ...
 ```
 
-The complete document can be found in the [Tic Tac Toe sample API](examples/tictactoe.yaml).
+The complete document can be found in the [Tic Tac Toe sample API](/examples/tictactoe.yaml).
 
 ## Summary
 


### PR DESCRIPTION
The previous path was not relative to the root of the repository so it wasn't working, now it directs to the correct folder (examples) and file.