### PR TITLE
Fixed other wrong paths for the Tic Tac Toe sample API

### DIFF
--- a/specification/components.md
+++ b/specification/components.md
@@ -97,7 +97,7 @@ Note also how the `coordinate` schema is used twice (in the `rowParam` and `colu
 
 ## Tic Tac Toe Example
 
-The complete [Tic Tac Toe sample API](examples/tictactoe.yaml) (not included here for brevity) makes heavy use of components. Note for example how different endpoints return a `#/components/schemas/status` on success, or a `#/components/schemas/errorMessage` on error.
+The complete [Tic Tac Toe sample API](/examples/tictactoe.yaml) (not included here for brevity) makes heavy use of components. Note for example how different endpoints return a `#/components/schemas/status` on success, or a `#/components/schemas/errorMessage` on error.
 
 ## Summary
 

--- a/specification/docs.md
+++ b/specification/docs.md
@@ -166,7 +166,7 @@ schema:
 
 On the other hand, the `examples` field (found in [Parameter](https://spec.openapis.org/oas/v3.1.0#parameterExample) and [Media Type](https://spec.openapis.org/oas/v3.1.0#mediaTypeExample) Objects) is a map pairing an example name with an [Example Object](https://spec.openapis.org/oas/v3.1.0#example-object). This object provides a `summary` and a `description` for the example along with the actual code (inside the `value` field or as an external reference in the `externalValue` field, but not both).
 
-This is a snippet from the [Tic Tac Toe sample API](examples/tictactoe.yaml):
+This is a snippet from the [Tic Tac Toe sample API](/examples/tictactoe.yaml):
 
 ```yaml
 responses:

--- a/specification/parameters.md
+++ b/specification/parameters.md
@@ -199,7 +199,7 @@ paths:
 - The parameters are two integers, named `row` and `column` which are located in the path of the operation. This matches the path name which contains `{row}` and `{column}`.
 - The `put` operation, additionally, must provide a request body which must be one of the three provided strings: `.`, `X` and `O`.
 
-The complete [Tic Tac Toe sample API](examples/tictactoe.yaml) does not look exactly like the above snippet because it reuses portions of the document to remove redundancy. This technique is explained in the [Reusing Descriptions](components) page.
+The complete [Tic Tac Toe sample API](/examples/tictactoe.yaml) does not look exactly like the above snippet because it reuses portions of the document to remove redundancy. This technique is explained in the [Reusing Descriptions](components) page.
 
 ## Summary
 


### PR DESCRIPTION
I'm sorry if I opened another pull request, I didn't notice these other paths in other pages (parameters,components,docs).
