### PR TITLE
chore: Add CNAME to point to learn.openapis.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+learn.openapis.org


### PR DESCRIPTION
Added `CNAME` file to point to `learn.openapis.org` at request from LF coordinator