### PR TITLE
Jekyll now requires jekyll-include-cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "jekyll-remote-theme"
 group :jekyll_plugins do
   gem "jekyll-sitemap", "~> 1.4"
 end
+
+gem "jekyll-include-cache", "~> 0.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-remote-theme (0.4.3)
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
@@ -79,6 +81,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.2)
+  jekyll-include-cache (~> 0.2.1)
   jekyll-remote-theme
   jekyll-sitemap (~> 1.4)
   just-the-docs (~> 0.3.3)


### PR DESCRIPTION
This requirement popped up from followiong the CONTRIBUTING instructions.  The local server would not start without this package.