### PR TITLE
update copyright year and add OG metadata for image previews

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,8 @@ title: OpenAPI Documentation
 description: For API designers and writers wishing formalize their API in an OpenAPI Description document.
 baseurl: /
 logo: "/assets/images/OpenAPI_Logo_Pantone-1.png"
-footer_content: "\xA9 2023 OpenAPI Initiative. <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\"\
+image: "/assets/images/OpenAPI_Logo_Pantone-1.png"
+footer_content: "\xA9 2025 OpenAPI Initiative. <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\"\
   ><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by/4.0/80x15.png\"\
   \ /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\"\
   >Creative Commons Attribution 4.0 International License</a>. The documentation is\

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -2,3 +2,11 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
 <style>.github-fork-ribbon:before { background-color: #1d781d; }</style>
 <a class="github-fork-ribbon" href="https://github.com/OAI/Documentation" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
+
+{%- assign og_image = page.image | default: site.image -%}
+
+<meta property="og:title" content="{{ page.title | default: site.title | escape }}" />
+<meta property="og:description" content="{{ page.excerpt | strip_html | truncate: 160 | default: site.description }}" />
+<meta property="og:image" content="{{ site.url }}{{ og_image }}" />
+<meta property="og:url" content="{{ page.url | absolute_url }}" />
+<meta property="og:type" content="website" />


### PR DESCRIPTION
Noticed a few small improvements when sharing the 3.1-->3.2 migration guide on socials.

- Updated footer copyright to 2025
- Added Open Graph metadata (title, description, image) to improve
  link previews on social and search